### PR TITLE
main.go: feat: use UPF_GITHUB_TOKEN prior to GITHUB_TOKEN

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,13 +30,21 @@ var (
 	}{}
 )
 
+func githubToken() string {
+	if tok := os.Getenv("UPF_GITHUB_TOKEN"); tok != "" {
+		return tok
+	}
+
+	return os.Getenv("GITHUB_TOKEN")
+}
+
 func init() {
 	flagset.BoolVar(&flags.Version, "version", false, "Print the version and exit")
 	flagset.BoolVar(&flags.Version, "v", false, "Print the Version and exit")
 
 	flagset.BoolVar(&flags.Latest, "latest", false, "Fetch the latest release")
 
-	flagset.StringVar(&flags.GHToken, "gh-token", os.Getenv("GITHUB_TOKEN"), "GitHub API token")
+	flagset.StringVar(&flags.GHToken, "gh-token", githubToken(), "GitHub API token")
 	flagset.StringVar(&flags.Asset, "a", "", "Asset name")
 	flagset.StringVar(&flags.Scheme, "s", "", "Scheme of the release")
 	flagset.StringVar(&flags.Output, "o", "", "Output location")


### PR DESCRIPTION
### What does this PR do?

This PR makes gh-downloader uses the token stored in `UPF_GITHUB_TOKEN` prior than `GITHUB_TOKEN`. 
The rationale here is that the `GITHUB_TOKEN` is also being interpreted by the `github-cli` and uses it by default.
As I don't want to share a common token with many the rights, I made `gh-downloader` actually use a token from the `UPF_GITHUB_TOKEN` env variable, then fallback to `GITHUB_TOKEN`.

### How to test this PR?

```
export GITHUB_TOKEN="xxxxxxxxx" # your token
# works
go run . --repository upfluence/upfluence-if -s activity-v0.0.45 -a activity-ruby.tar.gz -o ./bar.tar.gz

export UPF_GITHUB_TOKEN="${GITHUB_TOKEN}"
unset GITHUB_TOKEN

#still works
go run . --repository upfluence/upfluence-if -s activity-v0.0.45 -a activity-ruby.tar.gz -o ./bar.tar.gz
```