### PR TITLE
Make gh-downloader a github action on top of being a CLI tool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Easy! You can just download the binary from the command line:
 * Linux
 
 ```shell
-curl -sL https://github.com/upfluence/gh-downloader/releases/download/v0.0.1/gh-downloader-linux-amd64 > gh-downloader
+curl -sL https://github.com/upfluence/gh-downloader/releases/download/v0.1.0/gh-downloader-linux-amd64 > gh-downloader
 ```
 
 * OSX
 
 ```shell
-curl -sL https://github.com/upfluence/gh-downloader/releases/download/v0.0.1/gh-downloader-darwin-amd64 > gh-downloader
+curl -sL https://github.com/upfluence/gh-downloader/releases/download/v0.1.0/gh-downloader-darwin-amd64 > gh-downloader
 ```
 
 If you prefer compiling the binary (assuming buildtools and Go are
@@ -27,7 +27,9 @@ go install github.com/upfluence/gh-downloader/cmd/gh-downloader
 
 ## Usage
 
-### Options
+### CLI
+
+#### Options
 
 ```
 usage: gh-downloader [--gh-token] [--repository, -r] [--asset, -a] [--scheme, -s] [--latest] [--output, -o] [--mode]
@@ -40,7 +42,7 @@ Arguments:
 	- FileMode: main.fileMode File mode to create the output file in (default: 0644) (env: FILEMODE, flag: --mode)
 ```
 
-### Example
+#### Example
 
 Let's say you have a repositiory `upfluence/foo` and all the release are
 tagged such as `bar-0.0.1`, `bar-0.1.0` and so on.
@@ -55,4 +57,20 @@ you can also download the latest release with the major version 3
 
 ```shell
 gh-downloader -a mybin -gh-token="GITHUB_TOKEN.." -o mybin  -repository upfluence/foo -s "bar-v3.x.x"
+```
+
+### GitHub Action
+
+```
+on: push
+jobs:
+  gh-downloader:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: upfluence/gh-downloader@master
+      with:
+        repo: upfluence/ubuild
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        asset: ubuild-linux-amd64
+        output: ~/gh-action
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,33 @@
+name: 'gh-downloader'
+description: 'Download asset from a GitHub release according to a version scheme/template'
+inputs:
+  github-token:
+    description: 'github token to download the asset with'
+    required: true
+  repo:
+    description: 'what repo to downlaod the asset from'
+    required: true
+  asset:
+    description: 'the name of the asset of the release'
+    required: true
+  output:
+    description: 'where to output the asset'
+    required: true
+  mode:
+    description: 'the file mode of the file downloaded'
+    default: '0644'
+  scheme:
+    description: 'scheme of the release to pull the asset from (i.e. v1.x.x)'
+    default: ''
+runs:
+  using: "composite"
+  steps:
+    - run: curl -L https://github.com/upfluence/gh-downloader/releases/latest/download/gh-downloader-linux-amd64 > gh-downloader
+      shell: bash
+    - run: chmox +x gh-downloader
+      shell: bash
+    - run: ./gh-downloader -r ${{ inputs.repo }} -a ${{ inputs.asset }} -o ${{ inputs.output }} --mode ${{ inputs.mode }}
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        SCHEME: ${{ inputs.scheme }}


### PR DESCRIPTION
### What does this PR do?

In order to uniformally and easily deal with the downloading of asset from github releases i vendored this cli tool as a github action.

It will make our life easier to use cli tools from both private and public repository in a github action.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [x] Added/updated documentation
- [x] Properly labeled

### Additional Notes

This has not been tested yet. I put it out there so i can test it in other projects.