### PR TITLE
cmd/gh-downloader:  Make asset argument a templated value

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: true
   asset:
     description: 'the name of the asset of the release'
-    required: true
+    default: '{{ .repo }}-{{ .os }}-{{ .arch }}-{{ .tag }'
   output:
     description: 'where to output the asset'
     required: true

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: true
   asset:
     description: 'the name of the asset of the release'
-    default: '{{ .repo }}-{{ .os }}-{{ .arch }}-{{ .tag }'
+    default: '{{ .repo }}-{{ .os }}-{{ .arch }}-{{ .version }}'
   output:
     description: 'where to output the asset'
     required: true

--- a/cmd/gh-downloader/main.go
+++ b/cmd/gh-downloader/main.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-const assetFmt = "{{ .repo }}-{{ .os }}-{{ .arch }}-{{ .tag }}"
+const assetFmt = "{{ .repo }}-{{ .os }}-{{ .arch }}-{{ .version }}"
 
 var defaultConfig = config{
 	FileMode: 0644,
@@ -84,7 +84,7 @@ func (tc templateConfig) String() string { return tc.fmt }
 type config struct {
 	GithubToken string         `env:"GITHUB_TOKEN,UPF_GITHUB_TOKEN" flag:"gh-token" help:"GitHub API token"`
 	Repository  repoConfig     `flag:"repository,r" help:"Repository"`
-	Asset       templateConfig `flag:"asset,a" help:"Asset name, it can be given as a go template with variable including: .tag, .repo, .arch, .os"`
+	Asset       templateConfig `flag:"asset,a" help:"Asset name, it can be given as a go template with variable including: .tag, .repo, .arch, .os, .version"`
 	Scheme      string         `flag:"scheme,s" help:"Scheme of the release, if empty the latest release will be pulled"`
 	Output      string         `flag:"output,o" help:"Output location on disk, if left empty the file will be written on stdout"`
 	FileMode    fileMode       `flag:"mode" help:"File mode to create the output file in"`
@@ -195,11 +195,12 @@ func templateAssetName(c *config, r *github.RepositoryRelease) (string, error) {
 	if err := c.Asset.t.Execute(
 		&buf,
 		map[string]string{
-			"repo":  c.Repository.repo,
-			"owner": c.Repository.owner,
-			"tag":   *r.TagName,
-			"os":    runtime.GOOS,
-			"arch":  runtime.GOARCH,
+			"repo":    c.Repository.repo,
+			"owner":   c.Repository.owner,
+			"tag":     *r.TagName,
+			"os":      runtime.GOOS,
+			"arch":    runtime.GOARCH,
+			"version": strings.TrimPrefix(*r.TagName, "v"),
 		},
 	); err != nil {
 		return "", err

--- a/cmd/gh-downloader/tag.go
+++ b/cmd/gh-downloader/tag.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"strconv"
+	"fmt"
 	"strings"
 )
 
@@ -13,43 +13,29 @@ type tag struct {
 }
 
 func newTag(name string) *tag {
-	splittedTagName := strings.Split(name, "-")
-	project := ""
-	version := ""
+	var (
+		t tag
 
-	if len(splittedTagName) == 1 {
-		version = splittedTagName[0]
-	} else {
-		project = strings.Join(splittedTagName[:len(splittedTagName)-1], "-")
+		version = name
+	)
+
+	if splittedTagName := strings.Split(name, "-"); len(splittedTagName) > 1 {
+		t.Project = strings.Join(splittedTagName[:len(splittedTagName)-1], "-")
 		version = splittedTagName[len(splittedTagName)-1]
 	}
 
-	if version[0:1] == "v" {
-		version = version[1:]
-	}
-
-	splittedVersion := strings.Split(version, ".")
-
-	if len(splittedVersion) != 3 {
+	if n, err := fmt.Sscanf(
+		version,
+		"%d.%d.%d",
+		strings.TrimPrefix(version, "v"),
+		&t.Major,
+		&t.Minor,
+		&t.Patch,
+	); n != 3 || err != nil {
 		return nil
 	}
 
-	patch, err := strconv.Atoi(splittedVersion[2])
-	if err != nil {
-		patch = -1
-	}
-
-	minor, err := strconv.Atoi(splittedVersion[1])
-	if err != nil {
-		minor = -1
-	}
-
-	major, err := strconv.Atoi(splittedVersion[0])
-	if err != nil {
-		major = -1
-	}
-
-	return &tag{project, major, minor, patch}
+	return &t
 }
 
 func (t1 *tag) Less(t2 *tag) bool {


### PR DESCRIPTION
### What does this PR do?

In project like `ubuild` the asset name include the version. One goal of gh-downlaoder is to fetch the newest version from a specifc range hence you dont know the version. 

In order to solve this i made the Asset argument a go template. and you can pass `{{ .tag }}` instead of the hardcoded version to solve the topic.

On top of `.tag` i added some other use helper including:
* `.repo` name of the repo
* `.arch` arch gh-downloader been built with (most likely the arch of the host)
* `.os` os h-downloader been built with (most likely the os of the host)

### What are the observable changes?

In order to acheive CoC convention over configuration i added a default asset template that would match most of our asset.

So you can simply write:

```
$ gh-downloader -r ubuild
```

To download `ubuild-darwin-amd64-v0.2.1` from upfluence/ubuild

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [x] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
