### PR TITLE
tag: Fix the parser to handle version > 9

### DIFF
--- a/cmd/gh-downloader/release_test.go
+++ b/cmd/gh-downloader/release_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/google/go-github/github"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReleasesSort(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		with releases
+		want []string
+	}{
+		{
+			name: "path",
+			with: buildReleases("foo-1.2.100", "foo-1.2.2", "foo-1.2.30"),
+			want: []string{"foo-1.2.2", "foo-1.2.30", "foo-1.2.100"},
+		},
+		{
+			name: "minor",
+			with: buildReleases("foo-1.200.2", "foo-1.1.2", "foo-1.30.2"),
+			want: []string{"foo-1.1.2", "foo-1.30.2", "foo-1.200.2"},
+		},
+		{
+			name: "major",
+			with: buildReleases("foo-300.2.1", "foo-2.2.1", "foo-50.2.1"),
+			want: []string{"foo-2.2.1", "foo-50.2.1", "foo-300.2.1"},
+		},
+		{
+			name: "with suffix",
+			with: buildReleases("foo-1.2.2-rc19", "foo-1.2.2-rc10", "foo-1.2.2-rc1"),
+			want: []string{"foo-1.2.2-rc1", "foo-1.2.2-rc10", "foo-1.2.2-rc19"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			sort.Sort(tt.with)
+
+			var out = make([]string, len(tt.with))
+
+			for i, rr := range tt.with {
+				out[i] = *rr.TagName
+			}
+
+			assert.Equal(t, tt.want, out)
+		})
+	}
+}
+
+func newRelease(tag string) github.RepositoryRelease {
+	return github.RepositoryRelease{
+		TagName: &tag,
+	}
+}
+
+func buildReleases(tags ...string) releases {
+	var out releases
+
+	for _, t := range tags {
+		r := newRelease(t)
+		out = append(out, &r)
+	}
+
+	return out
+}

--- a/cmd/gh-downloader/tag.go
+++ b/cmd/gh-downloader/tag.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-var versionRe = regexp.MustCompile(`((\w+)-)?v?(\d|x).(\d|x).(\d|x)(-(\w+))?`)
+var versionRe = regexp.MustCompile(`((\w+)-)?v?(\d+|x).(\d+|x).(\d+|x)(-(\w+))?`)
 
 type tag struct {
 	Project string

--- a/cmd/gh-downloader/tag_test.go
+++ b/cmd/gh-downloader/tag_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewTag(t *testing.T) {
+	for _, tt := range []struct {
+		with string
+		want tag
+	}{
+		{
+			with: "foo-x.x.x",
+			want: tag{Project: "foo", Major: -1, Minor: -1, Patch: -1, Suffix: ""},
+		},
+		{
+			with: "foo-vx.x.x",
+			want: tag{Project: "foo", Major: -1, Minor: -1, Patch: -1, Suffix: ""},
+		},
+		{
+			with: "foo-1.2.3",
+			want: tag{Project: "foo", Major: 1, Minor: 2, Patch: 3, Suffix: ""},
+		},
+		{
+			with: "foo-v1.2.3",
+			want: tag{Project: "foo", Major: 1, Minor: 2, Patch: 3, Suffix: ""},
+		},
+		{
+			with: "foo-10.20.30",
+			want: tag{Project: "foo", Major: 10, Minor: 20, Patch: 30, Suffix: ""},
+		},
+		{
+			with: "foo-10.20.30-bar",
+			want: tag{Project: "foo", Major: 10, Minor: 20, Patch: 30, Suffix: "bar"},
+		},
+	} {
+		t.Run(tt.with, func(t *testing.T) {
+			tag := newTag(tt.with)
+
+			assert.Equal(t, tt.want, *tag)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/google/go-github v13.0.1-0.20171030212440-724ae38c5030+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/stretchr/testify v1.6.1
 	github.com/upfluence/cfg v0.2.3
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
 )

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,10 @@ github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQL
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -202,6 +204,7 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
### What does this PR do?

Update the parsing regex because the current one only work for version < 9.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [X] Title makes sense
- [X] Is against the correct branch
- [X] Only addresses one issue
- [X] Properly assigned
- [X] Added/updated tests
- [ ] Added/updated documentation
- [ ] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
